### PR TITLE
Fixes #12 : [User] Licence for driver but License in API

### DIFF
--- a/xee/entities.py
+++ b/xee/entities.py
@@ -26,7 +26,7 @@ User = collections.namedtuple(
         'nick_name',
         'gender',
         'birth_date',
-        'license_delivery_date',
+        'licence_delivery_date',
         'role',
         'is_location_enabled'
     ])
@@ -163,7 +163,7 @@ def parse_user(user):
         birth_date = isodate.parse_datetime(user['birthDate'])
     license_delivery_date = None
     if user['licenseDeliveryDate']:
-        license_delivery_date = isodate.parse_datetime(user['license_delivery_date'])
+        licence_delivery_date = isodate.parse_datetime(user['licenseDeliveryDate'])
     try:
         return User(
             user['id'],
@@ -172,7 +172,7 @@ def parse_user(user):
             user['nickName'],
             user['gender'],
             birth_date,
-            license_delivery_date,
+            licence_delivery_date,
             user['role'],
             user['isLocationEnabled']
         )

--- a/xee/version.py
+++ b/xee/version.py
@@ -4,4 +4,4 @@
     This package the version of the module
 """
 
-__version__ = "3.0.1"
+__version__ = "3.0.2-SNAPSHOT"


### PR DESCRIPTION
- In User object, the filed is `licenceDeliveryDate`
- In Xee API, the field is `licenseDeliveryDate`
